### PR TITLE
Fix order of interpolate_flag in radiometer

### DIFF
--- a/functions/unifyGrid_radiometer.m
+++ b/functions/unifyGrid_radiometer.m
@@ -307,10 +307,17 @@ uniRadiometer = removeTurnAscentDescentData(uniRadiometer, flightdate, pathtofol
 uniRadiometer_freq = round(100.*double(uniRadiometer_freq))./100;
 uniRadiometer_freq(uniRadiometer_freq==197.31) = 195.81;
 uniRadiometer_freq = single(uniRadiometer_freq);
-                  
-interpolate_flag = vertcat(interpolate_flag{:});
+
+% Order interpolate_flag the same way as uniRadiometer and uniRadiometer_freq
+interpolate_flagKV = interpolate_flag{find(cellfun(@(x) isequal(x, 'KV'), radiometerVars))};
+interpolate_flag11990 = interpolate_flag{find(cellfun(@(x) isequal(x, '11990'), radiometerVars))};
+interpolate_flag183 = interpolate_flag{find(cellfun(@(x) isequal(x, '183'), radiometerVars))};
+interpolate_flag = [interpolate_flagKV;...
+                    interpolate_flag11990;...
+                    interpolate_flag183];
 
 clear uniRadiometer11990* uniRadiometer183* uniRadiometerKV*
+clear interpolate_flagKV* interpolate_flag11990* interpolate_flag183*
 
 extra_info(end+1,:) = {'TB','K','Brightness temperature','uniRadiometer'};
 extra_info(end+1,:) = {'freq','GHz','channel center frequency','uniRadiometer_freq'};

--- a/functions/unifyGrid_radiometer.m
+++ b/functions/unifyGrid_radiometer.m
@@ -309,7 +309,7 @@ uniRadiometer_freq(uniRadiometer_freq==197.31) = 195.81;
 uniRadiometer_freq = single(uniRadiometer_freq);
 
 % Order interpolate_flag the same way as uniRadiometer and uniRadiometer_freq
-interpolate_flagKV = interpolate_flag{find(cellfun(@(x) isequal(x, 'KV'), radiometerVars))};
+interpolate_flagKV = interpolate_flag{cellfun(@(x) isequal(x, 'KV'), radiometerVars)};
 interpolate_flag11990 = interpolate_flag{find(cellfun(@(x) isequal(x, '11990'), radiometerVars))};
 interpolate_flag183 = interpolate_flag{find(cellfun(@(x) isequal(x, '183'), radiometerVars))};
 interpolate_flag = [interpolate_flagKV;...

--- a/functions/unifyGrid_radiometer.m
+++ b/functions/unifyGrid_radiometer.m
@@ -310,8 +310,8 @@ uniRadiometer_freq = single(uniRadiometer_freq);
 
 % Order interpolate_flag the same way as uniRadiometer and uniRadiometer_freq
 interpolate_flagKV = interpolate_flag{cellfun(@(x) isequal(x, 'KV'), radiometerVars)};
-interpolate_flag11990 = interpolate_flag{find(cellfun(@(x) isequal(x, '11990'), radiometerVars))};
-interpolate_flag183 = interpolate_flag{find(cellfun(@(x) isequal(x, '183'), radiometerVars))};
+interpolate_flag11990 = interpolate_flag{cellfun(@(x) isequal(x, '11990'), radiometerVars)};
+interpolate_flag183 = interpolate_flag{cellfun(@(x) isequal(x, '183'), radiometerVars)};
 interpolate_flag = [interpolate_flagKV;...
                     interpolate_flag11990;...
                     interpolate_flag183];


### PR DESCRIPTION
The order of interpolate_flag in the radiometer data does not align with the frequency vector. This patch might fix it, but I cloud not test it ;)